### PR TITLE
Fix annotation syntax for thread safety attributes

### DIFF
--- a/include/libstatistics_collector/collector/collector.hpp
+++ b/include/libstatistics_collector/collector/collector.hpp
@@ -112,20 +112,20 @@ private:
    *
    * @return true if setup was successful, false otherwise.
    */
-  virtual bool SetupStart() = 0 RCPPUTILS_TSA_REQUIRES(mutex_);
+  virtual bool SetupStart() RCPPUTILS_TSA_REQUIRES(mutex_) = 0;
 
   /**
    * Override in order to perform necessary teardown.
    *
    * @return true if teardown was successful, false otherwise.
    */
-  virtual bool SetupStop() = 0 RCPPUTILS_TSA_REQUIRES(mutex_);
+  virtual bool SetupStop() RCPPUTILS_TSA_REQUIRES(mutex_) = 0;
 
   mutable std::mutex mutex_;
 
   moving_average_statistics::MovingAverageStatistics collected_data_;
 
-  bool started_{false} RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  bool started_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = false;
 };
 
 }  // namespace collector

--- a/include/libstatistics_collector/moving_average_statistics/moving_average.hpp
+++ b/include/libstatistics_collector/moving_average_statistics/moving_average.hpp
@@ -126,11 +126,11 @@ public:
 
 private:
   mutable std::mutex mutex_;
-  double average_ = 0                              RCPPUTILS_TSA_GUARDED_BY(mutex_);
-  double min_ = std::numeric_limits<double>::max() RCPPUTILS_TSA_GUARDED_BY(mutex_);
-  double max_ = std::numeric_limits<double>::min() RCPPUTILS_TSA_GUARDED_BY(mutex_);
-  double sum_of_square_diff_from_mean_ = 0         RCPPUTILS_TSA_GUARDED_BY(mutex_);
-  uint64_t count_ = 0                              RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  double average_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
+  double min_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = std::numeric_limits<double>::max();
+  double max_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = std::numeric_limits<double>::min();
+  double sum_of_square_diff_from_mean_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
+  uint64_t count_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
 };
 
 }  // namespace moving_average_statistics

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -124,8 +124,8 @@ private:
   /**
    * Default uninitialized time.
    */
-  rcl_time_point_value_t time_last_message_received_{kUninitializedTime}
-  RCPPUTILS_TSA_GUARDED_BY(mutex_);
+  rcl_time_point_value_t time_last_message_received_ RCPPUTILS_TSA_GUARDED_BY(mutex_) =
+    kUninitializedTime;
   mutable std::mutex mutex_;
 };
 


### PR DESCRIPTION
It was not correct - causing build failures e.g.

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/404/console#console-section-10

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>