### PR TITLE
QD Security Vulnerability Declaration: REP 2006

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -192,4 +192,4 @@ Currently nightly build status can be seen here:
 
 ### Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy.
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).


### PR DESCRIPTION
This PR adds a link to REP-2006 (the Security Vulnerability Declaration) to the Quality Declaration for this repository.

FYI, this seems to touch every line because the script I used changed this from DOS line endings to Unix ones; I think we should keep it that way.

Connects to ros2/ros2#924.