### PR TITLE
Add autoapprove action for dependabot

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -1,0 +1,15 @@
+name: Auto approve
+
+on:
+  pull_request
+
+jobs:
+  # Auto-approve dependabot PRs. Dependabot will automatically merge minor version upgrades.
+  # (see .dependabot/config.yml for more info)
+  auto-approve-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Adds auto-approve workflow for `dependabot` PRs, similar to other repos in this org.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>