### PR TITLE
Check if message's "header" field is of type std_msgs::msg::Header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ if(BUILD_TESTING)
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"
+    "test/msg/DummyCustomHeaderMessage.msg"
     DEPENDENCIES "std_msgs"
     SKIP_INSTALL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_received_message_age
     test/topic_statistics_collector/test_received_message_age.cpp)
   target_link_libraries(test_received_message_age ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_age "rcl" "rcpputils" "std_msgs")
+  ament_target_dependencies(test_received_message_age "rcl" "rcpputils")
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(statistics_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/libstatistics_collector/collector/collector.cpp
@@ -51,7 +50,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "rcl"
   "rcpputils"
   "statistics_msgs"
-  "std_msgs")
+)
 
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
@@ -67,12 +66,13 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs" "std_msgs")
+ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(performance_test_fixture REQUIRED)
+  find_package(std_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 ament_target_dependencies(${PROJECT_NAME}
   "rcl"
   "rcpputils"
-  "statistics_msgs")
+  "statistics_msgs"
+  "std_msgs")
 
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
@@ -66,7 +67,7 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
+ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs" "std_msgs")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -93,7 +94,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_received_message_age
     test/topic_statistics_collector/test_received_message_age.cpp)
   target_link_libraries(test_received_message_age ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_age "rcl" "rcpputils")
+  ament_target_dependencies(test_received_message_age "rcl" "rcpputils" "std_msgs")
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -47,6 +48,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 ament_target_dependencies(${PROJECT_NAME}
+  "builtin_interfaces"
   "rcl"
   "rcpputils"
   "statistics_msgs"
@@ -66,7 +68,7 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
+ament_export_dependencies("builtin_interfaces" "rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -27,7 +27,7 @@
 
 #include "rcl/time.h"
 #include "rcutils/logging_macros.h"
-#include "std_msgs/msg/header.h"
+#include "std_msgs/msg/header.hpp"
 
 namespace libstatistics_collector
 {
@@ -45,9 +45,10 @@ struct HasHeader : public std::false_type {};
  * True if the message has a header of type Header
  * @tparam M
  */
-template<M>
+template<typename M>
 struct HasHeader<M, typename std::enable_if<std::is_same<std_msgs::msg::Header,
   decltype(M::header)>::value>::type>: std::true_type {};
+
 /**
  * Return a boolean flag indicating the timestamp is not set
  * and zero if the message does not have a header

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -43,13 +43,12 @@ struct HasHeader : public std::false_type {};
 
 /**
  * True if the message has a field named 'header' with a subfield named 'stamp' of
- * type builtin_interfaces::msg::Time, along with a subfield named 'frame_id' of type std::string
+ * type builtin_interfaces::msg::Time
  * @tparam M
  */
 template<typename M>
 struct HasHeader<M, typename std::enable_if<std::is_same<builtin_interfaces::msg::Time,
-  decltype(M().header.stamp)>::value &&
-  std::is_same<std::string, decltype(M().header.frame_id)>::value>::type>: public std::true_type {};
+  decltype(M().header.stamp)>::value>::type>: public std::true_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -41,11 +41,12 @@ template<typename M, typename = void>
 struct HasHeader : public std::false_type {};
 
 /**
- * True if the message has a header
+ * True if the message has a header of type Header
  * @tparam M
  */
 template<typename M>
-struct HasHeader<M, decltype((void) M::header)>: std::true_type {};
+struct HasHeader<M, typename std::enable_if<std::is_same<Header,
+  decltype(M::header)>::value>::type>: std::true_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -45,7 +45,7 @@ struct HasHeader : public std::false_type {};
  * @tparam M
  */
 template<typename M>
-struct HasHeader<M, typename std::enable_if<std::is_same<Header,
+struct HasHeader<M, typename std::enable_if<std::is_same<std_msgs::msg::Header,
   decltype(M::header)>::value>::type>: std::true_type {};
 
 /**

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -43,12 +43,13 @@ struct HasHeader : public std::false_type {};
 
 /**
  * True if the message has a field named 'header' with a subfield named 'stamp' of
- * type builtin_interfaces::msg::Time
+ * type builtin_interfaces::msg::Time, along with a subfield named 'frame_id' of type std::string
  * @tparam M
  */
 template<typename M>
 struct HasHeader<M, typename std::enable_if<std::is_same<builtin_interfaces::msg::Time,
-  decltype(M().header.stamp)>::value>::type>: public std::true_type {};
+  decltype(M().header.stamp)>::value &&
+  std::is_same<std::string, decltype(M().header.frame_id)>::value>::type>: public std::true_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -25,6 +25,7 @@
 
 #include "libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp"
 
+#include "builtin_interfaces/msg/time.hpp"
 #include "rcl/time.h"
 #include "rcutils/logging_macros.h"
 
@@ -34,18 +35,20 @@ namespace topic_statistics_collector
 {
 
 /**
- * True if the message has a header with a subfield stamp
- * @tparam M
- */
-template<typename M, typename D = decltype(M().header.stamp)>
-struct HasHeader : public std::true_type {};
-
-/**
  * False if the message does not have a header
  * @tparam M
  */
+template<typename M, typename = void>
+struct HasHeader : public std::false_type {};
+
+/**
+ * True if the message has a field named 'header' with a subfield named 'stamp' of
+ * type builtin_interfaces::msg::Time
+ * @tparam M
+ */
 template<typename M>
-struct HasHeader<M, void>: public std::false_type {};
+struct HasHeader<M, typename std::enable_if<std::is_same<builtin_interfaces::msg::Time,
+  decltype(M().header.stamp)>::value>::type>: public std::true_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -27,6 +27,7 @@
 
 #include "rcl/time.h"
 #include "rcutils/logging_macros.h"
+#include "std_msgs/msg/header.h"
 
 namespace libstatistics_collector
 {
@@ -44,10 +45,9 @@ struct HasHeader : public std::false_type {};
  * True if the message has a header of type Header
  * @tparam M
  */
-template<typename M>
+template<M>
 struct HasHeader<M, typename std::enable_if<std::is_same<std_msgs::msg::Header,
   decltype(M::header)>::value>::type>: std::true_type {};
-
 /**
  * Return a boolean flag indicating the timestamp is not set
  * and zero if the message does not have a header

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -27,7 +27,6 @@
 
 #include "rcl/time.h"
 #include "rcutils/logging_macros.h"
-#include "std_msgs/msg/header.hpp"
 
 namespace libstatistics_collector
 {
@@ -35,19 +34,18 @@ namespace topic_statistics_collector
 {
 
 /**
+ * True if the message has a header with a subfield stamp
+ * @tparam M
+ */
+template<typename M, typename D = decltype(M().header.stamp)>
+struct HasHeader : public std::true_type {};
+
+/**
  * False if the message does not have a header
  * @tparam M
  */
-template<typename M, typename = void>
-struct HasHeader : public std::false_type {};
-
-/**
- * True if the message has a header of type Header
- * @tparam M
- */
 template<typename M>
-struct HasHeader<M, typename std::enable_if<std::is_same<std_msgs::msg::Header,
-  decltype(M::header)>::value>::type>: std::true_type {};
+struct HasHeader<M, void>: public std::false_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/package.xml
+++ b/package.xml
@@ -11,11 +11,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
-  <!-- TODO(clalancette): This dependency is really wrong; std_msgs is only used
-       as part of the tests.  But it turns out that rosidl_generate_interfaces()
-       always adds it to the exported dependencies, so we need to export this
-       incorrect dependency for now
-  -->
   <build_depend>std_msgs</build_depend>
 
   <depend>builtin_interfaces</depend>

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <depend>rcl</depend>
   <depend>rcpputils</depend>
   <depend>statistics_msgs</depend>
-  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
@@ -23,6 +22,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>std_msgs</build_depend>
 
   <depend>rcl</depend>
   <depend>rcpputils</depend>
@@ -19,7 +18,6 @@
   <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>rcl</depend>
   <depend>rcpputils</depend>
   <depend>statistics_msgs</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,12 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
+  <!-- TODO(clalancette): This dependency is really wrong; std_msgs is only used
+       as part of the tests.  But it turns out that rosidl_generate_interfaces()
+       always adds it to the exported dependencies, so we need to export this
+       incorrect dependency for now
+  -->
+  <build_depend>std_msgs</build_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>rcl</depend>
@@ -18,12 +24,12 @@
   <depend>statistics_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>
-  <test_depend>std_msgs</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>builtin_interfaces</depend>
   <depend>rcl</depend>
   <depend>rcpputils</depend>
   <depend>statistics_msgs</depend>

--- a/test/msg/DummyCustomHeaderMessage.msg
+++ b/test/msg/DummyCustomHeaderMessage.msg
@@ -1,0 +1,4 @@
+# This is a dummy message type with a custom header field that is not type `Header`.
+# It is intended for use in topic statistics tests.
+
+std_msgs/ColorRGBA header

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -70,7 +70,8 @@ TEST(ReceivedMessageAgeTest, TestOnlyMessagesWithHeaderGetSampled) {
   ReceivedDummyCustomHeaderMessageAgeCollector dummy_custom_header_msg_collector{};
   auto msg_custom_header = DummyCustomHeaderMessage{};
   for (int i = 0; i < kDefaultTimesToTest; ++i) {
-    dummy_custom_header_msg_collector.OnMessageReceived(msg_custom_header,
+    dummy_custom_header_msg_collector.OnMessageReceived(
+      msg_custom_header,
       kDefaultTimeMessageReceived);
     stats = dummy_custom_header_msg_collector.GetStatisticsResults();
     EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "libstatistics_collector/msg/dummy_message.hpp"
+#include "libstatistics_collector/msg/dummy_custom_header_message.hpp"
 #include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
 
@@ -30,6 +31,9 @@ using ReceivedDummyMessageAgeCollector = libstatistics_collector::
   topic_statistics_collector::ReceivedMessageAgeCollector<DummyMessage>;
 using ReceivedIntMessageAgeCollector = libstatistics_collector::
   topic_statistics_collector::ReceivedMessageAgeCollector<int>;
+using DummyCustomHeaderMessage = libstatistics_collector::msg::DummyCustomHeaderMessage;
+using ReceivedDummyCustomHeaderMessageAgeCollector = libstatistics_collector::
+  topic_statistics_collector::ReceivedMessageAgeCollector<DummyCustomHeaderMessage>;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{2000.0};
@@ -61,6 +65,15 @@ TEST(ReceivedMessageAgeTest, TestOnlyMessagesWithHeaderGetSampled) {
     dummy_msg_collector.OnMessageReceived(msg, kDefaultTimeMessageReceived);
     stats = dummy_msg_collector.GetStatisticsResults();
     EXPECT_EQ(i + 1, stats.sample_count) << "Expect " << i + 1 << " samples to be collected";
+  }
+
+  ReceivedDummyCustomHeaderMessageAgeCollector dummy_custom_header_msg_collector{};
+  auto msg_custom_header = DummyCustomHeaderMessage{};
+  for (int i = 0; i < kDefaultTimesToTest; ++i) {
+    dummy_custom_header_msg_collector.OnMessageReceived(msg_custom_header,
+      kDefaultTimeMessageReceived);
+    stats = dummy_custom_header_msg_collector.GetStatisticsResults();
+    EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
   }
 }
 


### PR DESCRIPTION
Resolves #51 
HasHeader function in received_message_age.hpp will now check to make sure that member of name "header" is also of type std_msgs::msg::Header to return true.