### PR TITLE
Remove unnecessary build dependency on std_msgs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,7 @@ if(BUILD_TESTING)
     "test/msg/DummyMessage.msg"
     "test/msg/DummyCustomHeaderMessage.msg"
     DEPENDENCIES "std_msgs"
-    SKIP_INSTALL
-    SKIP_EXPORT_DEPENDENCIES
-    SKIP_GROUP_MEMBERSHIP_CHECK)
+    SKIP_INSTALL)
 
   # To enable use of dummy_message.hpp in test_received_message_age
   rosidl_get_typesupport_target(cpp_typesupport_target libstatistics_collector_test_msgs "rosidl_typesupport_cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,10 @@ if(WIN32)
 endif()
 
 # find dependencies
-find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
 find_package(statistics_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
@@ -74,6 +72,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(performance_test_fixture REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
   find_package(std_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
@@ -102,7 +101,9 @@ if(BUILD_TESTING)
     "test/msg/DummyMessage.msg"
     "test/msg/DummyCustomHeaderMessage.msg"
     DEPENDENCIES "std_msgs"
-    SKIP_INSTALL)
+    SKIP_INSTALL
+    SKIP_EXPORT_DEPENDENCIES
+    SKIP_GROUP_MEMBERSHIP_CHECK)
 
   # To enable use of dummy_message.hpp in test_received_message_age
   rosidl_get_typesupport_target(cpp_typesupport_target libstatistics_collector_test_msgs "rosidl_typesupport_cpp")

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -27,7 +27,6 @@
 
 #include "builtin_interfaces/msg/time.hpp"
 #include "rcl/time.h"
-#include "rcutils/logging_macros.h"
 
 namespace libstatistics_collector
 {

--- a/package.xml
+++ b/package.xml
@@ -7,26 +7,20 @@
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-
-  <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>std_msgs</build_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>rcl</depend>
   <depend>rcpputils</depend>
   <depend>statistics_msgs</depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
+  <test_depend>rosidl_default_generators</test_depend>
+  <test_depend>rosidl_default_runtime</test_depend>
+  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Instead, make it a test_depend, which is much more appropriate. We also make it so that we don't export the 'std_msgs' dependency to downstream packages, as only our tests depend on it.

While we were in here cleaning things up, make a couple of other minor fixes:

1.  Remove an unnecessary #include to rcutils.
2.  Remove a duplicated call to ament_cmake; that is already a transitive dependency via ament_cmake_ros.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this depends on https://github.com/ros2/rosidl/pull/708 to fully work.

Fixes #144 