### PR TITLE
Cleanup the CI jobs on this repository.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,7 +3,7 @@ name: Auto merge
 on:
   pull_request:
     branches:
-      master
+      rolling
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   ament_lint:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linter: [copyright, cppcheck, cpplint, flake8, pep257, uncrustify, xmllint]
+        linter: [copyright, cpplint, flake8, pep257, uncrustify, xmllint]
     steps:
       - uses: actions/checkout@v3
       - uses: ros-tooling/action-ros-lint@v0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,44 +3,24 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - rolling
   schedule:
     # Run every hour. This helps detect flakiness,
     # and broken external dependencies.
     - cron:  '0 * * * *'
 
 jobs:
-  build_and_test_macOS:
-    runs-on: macOS-latest
-    steps:
-    - uses: ros-tooling/setup-ros@0.4.0
-    - uses: ros-tooling/action-ros-ci@v0.2
-      with:
-        package-name: libstatistics_collector
-        colcon-defaults: |
-          {
-            "build": {
-              "mixin": ["coverage-gcc"]
-            }
-          }
-        target-ros2-distro: rolling
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
-    - uses: actions/upload-artifact@v3
-      with:
-        name: colcon-logs-${{ matrix.os }}
-        path: ros_ws/log
-
   build_and_test_ubuntu:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - uses: ros-tooling/action-ros-ci@v0.1
       with:
         package-name: libstatistics_collector
         colcon-mixin-name: coverage-gcc
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-        target-ros2-distro: foxy
+        target-ros2-distro: rolling
     - uses: codecov/codecov-action@v3.1.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -57,14 +37,14 @@ jobs:
   build_and_test_asan:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - uses: ros-tooling/action-ros-ci@v0.1
       with:
         colcon-mixin-name: asan
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         package-name: libstatistics_collector
-        target-ros2-distro: foxy
+        target-ros2-distro: rolling
     - uses: actions/upload-artifact@v3
       with:
         name: colcon-logs-ubuntu-asan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
-    - uses: ros-tooling/action-ros-ci@v0.1
+    - uses: ros-tooling/action-ros-ci@v0.2
       with:
         package-name: libstatistics_collector
         colcon-mixin-name: coverage-gcc
@@ -39,7 +39,7 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
-    - uses: ros-tooling/action-ros-ci@v0.1
+    - uses: ros-tooling/action-ros-ci@v0.2
       with:
         colcon-mixin-name: asan
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml


### PR DESCRIPTION
1.  Remove macOS, as it is no longer a supported platform.
2.  Switch to Jammy for our container images, as that is the latest.
3.  Switch the target ROS distribution to 'rolling', as that is what the 'rolling' branch targets
4.  Switch some of the branch names used from 'master' to 'rolling', as that is the new default branch name.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #124 