### PR TITLE
Humble: Check if message has a "header" field with a stamp subfield of type builtin_interfaces::msg::Time (#51)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,11 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(statistics_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
   src/libstatistics_collector/collector/collector.cpp
@@ -48,9 +48,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 ament_target_dependencies(${PROJECT_NAME}
+  "builtin_interfaces"
   "rcl"
   "rcpputils"
-  "statistics_msgs")
+  "statistics_msgs"
+)
 
 install(
   TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
@@ -66,12 +68,13 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies("rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
+ament_export_dependencies("builtin_interfaces" "rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(performance_test_fixture REQUIRED)
+  find_package(std_msgs REQUIRED)
 
   ament_lint_auto_find_test_dependencies()
 
@@ -97,6 +100,7 @@ if(BUILD_TESTING)
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"
+    "test/msg/DummyCustomHeaderMessage.msg"
     DEPENDENCIES "std_msgs"
     SKIP_INSTALL)
 

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -25,6 +25,7 @@
 
 #include "libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp"
 
+#include "builtin_interfaces/msg/time.hpp"
 #include "rcl/time.h"
 #include "rcutils/logging_macros.h"
 
@@ -41,11 +42,13 @@ template<typename M, typename = void>
 struct HasHeader : public std::false_type {};
 
 /**
- * True if the message has a header
+ * True if the message has a field named 'header' with a subfield named 'stamp' of
+ * type builtin_interfaces::msg::Time
  * @tparam M
  */
 template<typename M>
-struct HasHeader<M, decltype((void) M::header)>: std::true_type {};
+struct HasHeader<M, typename std::enable_if<std::is_same<builtin_interfaces::msg::Time,
+  decltype(M().header.stamp)>::value>::type>: public std::true_type {};
 
 /**
  * Return a boolean flag indicating the timestamp is not set

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <depend>builtin_interfaces</depend>
   <depend>rcl</depend>
   <depend>rcpputils</depend>
   <depend>statistics_msgs</depend>

--- a/test/msg/DummyCustomHeaderMessage.msg
+++ b/test/msg/DummyCustomHeaderMessage.msg
@@ -1,0 +1,4 @@
+# This is a dummy message type with a custom header field that is not type `Header`.
+# It is intended for use in topic statistics tests.
+
+std_msgs/ColorRGBA header

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "libstatistics_collector/msg/dummy_message.hpp"
+#include "libstatistics_collector/msg/dummy_custom_header_message.hpp"
 #include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
 
@@ -30,6 +31,9 @@ using ReceivedDummyMessageAgeCollector = libstatistics_collector::
   topic_statistics_collector::ReceivedMessageAgeCollector<DummyMessage>;
 using ReceivedIntMessageAgeCollector = libstatistics_collector::
   topic_statistics_collector::ReceivedMessageAgeCollector<int>;
+using DummyCustomHeaderMessage = libstatistics_collector::msg::DummyCustomHeaderMessage;
+using ReceivedDummyCustomHeaderMessageAgeCollector = libstatistics_collector::
+  topic_statistics_collector::ReceivedMessageAgeCollector<DummyCustomHeaderMessage>;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{2000.0};
@@ -61,6 +65,16 @@ TEST(ReceivedMessageAgeTest, TestOnlyMessagesWithHeaderGetSampled) {
     dummy_msg_collector.OnMessageReceived(msg, kDefaultTimeMessageReceived);
     stats = dummy_msg_collector.GetStatisticsResults();
     EXPECT_EQ(i + 1, stats.sample_count) << "Expect " << i + 1 << " samples to be collected";
+  }
+
+  ReceivedDummyCustomHeaderMessageAgeCollector dummy_custom_header_msg_collector{};
+  auto msg_custom_header = DummyCustomHeaderMessage{};
+  for (int i = 0; i < kDefaultTimesToTest; ++i) {
+    dummy_custom_header_msg_collector.OnMessageReceived(
+      msg_custom_header,
+      kDefaultTimeMessageReceived);
+    stats = dummy_custom_header_msg_collector.GetStatisticsResults();
+    EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
   }
 }
 


### PR DESCRIPTION
As per request here: https://github.com/ros-tooling/libstatistics_collector/issues/152#issuecomment-1377670831