### PR TITLE
Mark benchmark _ as unused.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>performance_test_fixture</test_depend>
+  <test_depend>rcutils</test_depend>
   <test_depend>rosidl_default_generators</test_depend>
   <test_depend>rosidl_default_runtime</test_depend>
   <test_depend>std_msgs</test_depend>

--- a/test/benchmark/benchmark_iterative.cpp
+++ b/test/benchmark/benchmark_iterative.cpp
@@ -19,6 +19,8 @@
 
 #include "performance_test_fixture/performance_test_fixture.hpp"
 
+#include "rcutils/macros.h"
+
 using performance_test_fixture::PerformanceTest;
 using libstatistics_collector::moving_average_statistics::MovingAverageStatistics;
 using libstatistics_collector::collector::Collector;
@@ -82,6 +84,7 @@ BENCHMARK_F(PerformanceTest, collector_accept_data)(benchmark::State & st)
   TestCollector collector;
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     collector.AcceptData(0);
   }
 }
@@ -92,6 +95,7 @@ BENCHMARK_F(PerformanceTest, add_measurement)(benchmark::State & st)
   MovingAverageStatistics moving_average_statistics;
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     moving_average_statistics.AddMeasurement(0);
   }
 }


### PR DESCRIPTION
This is just to keep clang static analysis happy.