### PR TITLE
Bump rolling to 1.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package libstatistics_collector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add in missing cstdint include. (`#165 <https://github.com/ros-tooling/libstatistics_collector/issues/165>`_)
+* Contributors: Chris Lalancette
+
 1.6.0 (2023-04-28)
 ------------------
 * Bump codecov/codecov-action from 3.1.2 to 3.1.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package libstatistics_collector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.6.1 (2023-05-11)
+------------------
 * Add in missing cstdint include. (`#165 <https://github.com/ros-tooling/libstatistics_collector/issues/165>`_)
 * Contributors: Chris Lalancette
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>libstatistics_collector</name>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <description>Lightweight aggregation utilities to collect statistics and measure message metrics.</description>
   <maintainer email="ros-tooling@googlegroups.com">ROS Tooling Working Group</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Wasn't able to push directly to `rolling` via `catkin_prepare_release` due to branch protection rules.
Once this is merged, will bloom to rolling.

I've tagged the latest commit so it might be better to do a merge commit if we want to keep the tag on `rolling`.