### PR TITLE
Add API to use message_info instead unserialized message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(rmw REQUIRED)
 find_package(statistics_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
@@ -49,6 +50,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 ament_target_dependencies(${PROJECT_NAME}
   "builtin_interfaces"
   "rcl"
+  "rmw"
   "rcpputils"
   "statistics_msgs"
 )
@@ -67,7 +69,7 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies("builtin_interfaces" "rcl" "rcpputils" "rosidl_default_runtime" "statistics_msgs")
+ament_export_dependencies("builtin_interfaces" "rcl" "rcpputils" "rmw" "rosidl_default_runtime" "statistics_msgs")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,12 +93,12 @@ if(BUILD_TESTING)
   ament_add_gtest(test_received_message_period
     test/topic_statistics_collector/test_received_message_period.cpp)
   target_link_libraries(test_received_message_period ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_period "rcl" "rcpputils")
+  ament_target_dependencies(test_received_message_period "rcl" "rmw" "rcpputils")
 
   ament_add_gtest(test_received_message_age
     test/topic_statistics_collector/test_received_message_age.cpp)
   target_link_libraries(test_received_message_age ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_age "rcl" "rcpputils")
+  ament_target_dependencies(test_received_message_age "rcl" "rmw" "rcpputils")
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -94,7 +94,7 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
 {};
 
 /**
- * Class used to measure the received messsage, tparam T, age from a ROS2 subscriber.
+ * Class used to measure the received message, tparam T, age from a ROS2 subscriber.
  *
  * @tparam T the message type to receive from the subscriber / listener
 */
@@ -144,7 +144,7 @@ public:
   }
 
   /**
-   * Return messge age metric unit
+   * Return message age metric unit
    *
    * @return a string representing messager age metric unit
    */
@@ -166,7 +166,7 @@ protected:
 };
 
 /**
- * Class used to measure the received messsage age from a ROS2 subscriber.
+ * Class used to measure the received message age from a ROS2 subscriber.
 */
 template<>
 class ReceivedMessageAgeCollector<
@@ -210,9 +210,9 @@ public:
   }
 
   /**
-   * Return messge age metric unit
+   * Return message age metric unit
    *
-   * @return a string representing messager age metric unit
+   * @return a string representing message age metric unit
    */
   std::string GetMetricUnit() const override
   {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -104,8 +104,7 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
 template<typename T>
 class
   [[deprecated("Don't use templated version of the ReceivedMessageAgeCollector, use"
-  "libstatistics_collector::ReceivedMessageAgeCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::ReceivedMessageAgeCollector alias instead")]]
   ReceivedMessageAgeCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -88,6 +88,9 @@ struct TimeStamp<M, typename std::enable_if<HasHeader<M>::value>::type>
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the ReceivedMessageAgeCollector, use
+ * libstatistics_collector::ReceivedMessageAgeCollector alias with rmw_message_info_t
+ * parameter in the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
@@ -99,11 +102,18 @@ class ReceivedMessageAgeCollector : public TopicStatisticsCollector<T>
  * @tparam T the message type to receive from the subscriber / listener
 */
 template<typename T>
-class ReceivedMessageAgeCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the ReceivedMessageAgeCollector, use"
+  "libstatistics_collector::ReceivedMessageAgeCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  ReceivedMessageAgeCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {
 public:
+  /**
+   * Construct a ReceivedMessageAgeCollector object.
+   *
+   */
   ReceivedMessageAgeCollector() = default;
 
   virtual ~ReceivedMessageAgeCollector() = default;
@@ -114,8 +124,6 @@ public:
   * @param received_message the message to calculate age of.
   * @param now_nanoseconds time the message was received in nanoseconds
   */
-  [[deprecated("Don't use ReceivedMessageAgeCollector with type T, use rmw_message_info_t"
-  "with an untyped ReceivedMessageAgeCollector<>")]]
   void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) override
@@ -177,7 +185,7 @@ class ReceivedMessageAgeCollector<
 public:
   ReceivedMessageAgeCollector() = default;
 
-  virtual ~ReceivedMessageAgeCollector() = default;
+  ~ReceivedMessageAgeCollector() override = default;
 
   /**
   * Handle a new incoming message. Calculate message age if timestamps in message info are valid.
@@ -232,6 +240,9 @@ protected:
 };
 
 }  // namespace topic_statistics_collector
+
+using ReceivedMessageAgeCollector = topic_statistics_collector::ReceivedMessageAgeCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_AGE_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -133,8 +133,8 @@ public:
   {
     // only compare if non-zero
     if (received_message.source_timestamp && received_message.received_timestamp) {
-      const std::chrono::nanoseconds age_nanos{received_message.received_timestamp
-        - received_message.source_timestamp};
+      const std::chrono::nanoseconds age_nanos{received_message.received_timestamp -
+        received_message.source_timestamp};
       const auto age_millis = std::chrono::duration<double, std::milli>(age_nanos);
 
       collector::Collector::AcceptData(static_cast<double>(age_millis.count()));

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_age.hpp
@@ -180,19 +180,19 @@ public:
   virtual ~ReceivedMessageAgeCollector() = default;
 
   /**
-  * Handle a new incoming message. Calculate message age if a valid Header is present.
+  * Handle a new incoming message. Calculate message age if timestamps in message info are valid.
   *
-  * @param received_message the message to calculate age of.
+  * @param message_info the message information of the received message.
   * @param now_nanoseconds time the message was received in nanoseconds
   */
   void OnMessageReceived(
-    const rmw_message_info_t & received_message,
+    const rmw_message_info_t & message_info,
     const rcl_time_point_value_t now_nanoseconds) override
   {
     // only compare if non-zero
-    if (received_message.source_timestamp && now_nanoseconds) {
+    if (message_info.source_timestamp && now_nanoseconds) {
       const std::chrono::nanoseconds age_nanos{now_nanoseconds -
-        received_message.source_timestamp};
+        message_info.source_timestamp};
       const auto age_millis = std::chrono::duration<double, std::milli>(age_nanos);
 
       collector::Collector::AcceptData(static_cast<double>(age_millis.count()));

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -35,6 +35,9 @@ constexpr const int64_t kUninitializedTime{0};
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the ReceivedMessagePeriodCollector, use
+ * libstatistics_collector::ReceivedMessagePeriodCollector alias with rmw_message_info_t
+ * parameter in the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
@@ -47,8 +50,11 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
  * @tparam T the message type to receive from the subscriber / listener
 */
 template<typename T>
-class ReceivedMessagePeriodCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the ReceivedMessagePeriodCollector, use"
+  "libstatistics_collector::ReceivedMessagePeriodCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  ReceivedMessagePeriodCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {
 public:
@@ -70,8 +76,6 @@ public:
    * @param received_message
    * @param now_nanoseconds time the message was received in nanoseconds
    */
-  [[deprecated("Don't use ReceivedMessagePeriodCollector with type T, use rmw_message_info_t"
-  "with an untyped ReceivedMessagePeriodCollector<>")]]
   void OnMessageReceived(const T & received_message, const rcl_time_point_value_t now_nanoseconds)
   override RCPPUTILS_TSA_REQUIRES(mutex_)
   {
@@ -143,7 +147,8 @@ private:
 };
 
 template<>
-class ReceivedMessagePeriodCollector<rmw_message_info_t,
+class ReceivedMessagePeriodCollector<
+    rmw_message_info_t,
     std::enable_if_t<std::is_same<rmw_message_info_t, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<>
 {
@@ -157,7 +162,7 @@ public:
     ResetTimeLastMessageReceived();
   }
 
-  virtual ~ReceivedMessagePeriodCollector() = default;
+  ~ReceivedMessagePeriodCollector() override = default;
 
   /**
    * Handle a message received and measure its received period. This member is thread safe and acquires
@@ -237,6 +242,9 @@ private:
 };
 
 }  // namespace topic_statistics_collector
+
+using ReceivedMessagePeriodCollector = topic_statistics_collector::ReceivedMessagePeriodCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__RECEIVED_MESSAGE_PERIOD_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -52,8 +52,7 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
 template<typename T>
 class
   [[deprecated("Don't use templated version of the ReceivedMessagePeriodCollector, use"
-  "libstatistics_collector::ReceivedMessagePeriodCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::ReceivedMessagePeriodCollector alias instead")]]
   ReceivedMessagePeriodCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public TopicStatisticsCollector<T>
 {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -163,11 +163,11 @@ public:
    * Handle a message received and measure its received period. This member is thread safe and acquires
    * a lock to prevent race conditions when setting the time_last_message_received_ member.
    *
-   * @param received_message
+   * @param message_info the message information of the received message
    * @param now_nanoseconds time the message was received in nanoseconds
    */
   void OnMessageReceived(
-    const rmw_message_info_t & received_message,
+    const rmw_message_info_t & message_info,
     const rcl_time_point_value_t now_nanoseconds)
   override RCPPUTILS_TSA_REQUIRES(mutex_)
   {

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -24,6 +24,8 @@
 
 #include "rcl/time.h"
 
+#include "rmw/types.h"
+
 namespace libstatistics_collector
 {
 namespace topic_statistics_collector

--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -41,7 +41,7 @@ class ReceivedMessagePeriodCollector : public TopicStatisticsCollector<T>
 {};
 
 /**
- * Class used to measure the received messsage, tparam T, period from a ROS2 subscriber. This class
+ * Class used to measure the received message, tparam T, period from a ROS2 subscriber. This class
  * is thread safe and acquires a mutex when the member OnMessageReceived is executed.
  *
  * @tparam T the message type to receive from the subscriber / listener

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -32,6 +32,9 @@ namespace topic_statistics_collector
 
 /**
  * Primary specialization class template until deprecated templated class is phased out
+ * @warning Don't use templated version of the TopicStatisticsCollector, use
+ * libstatistics_collector::TopicStatisticsCollector alias with rmw_message_info_t parameter in
+ * the OnMessageReceived callback
  */
 template<typename T = rmw_message_info_t, typename Enable = void>
 class TopicStatisticsCollector : public collector::Collector
@@ -43,8 +46,11 @@ class TopicStatisticsCollector : public collector::Collector
  * @tparam T the ROS2 message type to collect
  */
 template<typename T>
-class TopicStatisticsCollector<
-    T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
+class
+  [[deprecated("Don't use templated version of the TopicStatisticsCollector, use"
+  "libstatistics_collector::TopicStatisticsCollector with rmw_message_info_t parameter in the"
+  "OnMessageReceived callback")]]
+  TopicStatisticsCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public collector::Collector
 {
 public:
@@ -60,8 +66,6 @@ public:
    * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
    * as time obtained from the message header.
    */
-  [[deprecated("Don't use TopicStatisticsCollector with type T, use rmw_message_info_t"
-  "with an untyped TopicStatisticsCollector<>")]]
   virtual void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) = 0;
@@ -78,15 +82,16 @@ class TopicStatisticsCollector<rmw_message_info_t,
 public:
   TopicStatisticsCollector() = default;
 
-  virtual ~TopicStatisticsCollector() = default;
+  ~TopicStatisticsCollector() override = default;
 
   /**
    * Handle receiving a single message of type rmw_message_info_t.
    *
    * @param received_message rmw_message_info_t the ROS2 message type to collect
-   * @param now_nanoseconds nanoseconds the time the message was received. Any metrics using this time assumes the
-   * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
-   * as time obtained from the message header.
+   * @param now_nanoseconds nanoseconds the time the message was received.
+   * Any metrics using this time assumes the following:
+   * 1). the time provided is strictly monotonic
+   * 2). the time provided uses the same source as time obtained from the message header.
    */
   virtual void OnMessageReceived(
     const rmw_message_info_t & received_message,
@@ -94,6 +99,9 @@ public:
 };
 
 }  // namespace topic_statistics_collector
+
+using TopicStatisticsCollector = topic_statistics_collector::TopicStatisticsCollector<>;
+
 }  // namespace libstatistics_collector
 
 #endif  // LIBSTATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR__TOPIC_STATISTICS_COLLECTOR_HPP_

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -21,6 +21,8 @@
 
 #include "rcl/time.h"
 
+#include "rmw/types.h"
+
 #include "libstatistics_collector/collector/collector.hpp"
 
 namespace libstatistics_collector
@@ -49,9 +51,21 @@ public:
    * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
    * as time obtained from the message header.
    */
+  [[deprecated("Use rmw_message_info_t instead of custom type T")]]
   virtual void OnMessageReceived(
     const T & received_message,
     const rcl_time_point_value_t now_nanoseconds) = 0;
+
+  /**
+   * Handle receiving a single message of type rmw_message_info_t.
+   *
+   * @param received_message rmw_message_info_t the ROS2 message info to collect
+   * @param now_nanoseconds nanoseconds the time the message was received. Any metrics using this time assumes the
+   * following 1). the time provided is strictly monotonic 2). the time provided uses the same source
+   * as time obtained from the message header.
+   */
+  virtual void OnMessageReceived(
+    const rmw_message_info_t & received_message) = 0;
 };
 
 }  // namespace topic_statistics_collector

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -48,8 +48,7 @@ class TopicStatisticsCollector : public collector::Collector
 template<typename T>
 class
   [[deprecated("Don't use templated version of the TopicStatisticsCollector, use"
-  "libstatistics_collector::TopicStatisticsCollector with rmw_message_info_t parameter in the"
-  "OnMessageReceived callback")]]
+  "libstatistics_collector::TopicStatisticsCollector alias instead")]]
   TopicStatisticsCollector<T, std::enable_if_t<!std::is_same<T, rmw_message_info_t>::value>>
   : public collector::Collector
 {

--- a/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/topic_statistics_collector.hpp
@@ -82,7 +82,7 @@ class TopicStatisticsCollector<rmw_message_info_t,
 public:
   TopicStatisticsCollector() = default;
 
-  ~TopicStatisticsCollector() override = default;
+  virtual ~TopicStatisticsCollector() = default;
 
   /**
    * Handle receiving a single message of type rmw_message_info_t.

--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <depend>builtin_interfaces</depend>
   <depend>rcl</depend>
   <depend>rcpputils</depend>
+  <depend>rmw</depend>
   <depend>statistics_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -24,7 +24,7 @@
 
 #include "rcl/time.h"
 
-#include "rcl/types.h"
+#include "rmw/types.h"
 
 namespace
 {

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -22,8 +22,7 @@
 
 namespace
 {
-using ReceivedMessageAgeCollector = libstatistics_collector::
-  topic_statistics_collector::ReceivedMessageAgeCollector<>;
+using ReceivedMessageAgeCollector = libstatistics_collector::ReceivedMessageAgeCollector;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{2000.0};

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -39,8 +39,6 @@ constexpr const double kExpectedStandardDeviation{816.49658092772597};
 constexpr const int kDefaultTimesToTest{10};
 constexpr const int64_t kDefaultTimeMessageReceived{1000};
 constexpr const rcl_time_point_value_t kStartTime{123456789};
-constexpr const int kRandomIntMessage{7};
-
 }  // namespace
 
 TEST(ReceivedMessageAgeTest, TestMessagesWithDifferentDefaultTimes) {
@@ -69,6 +67,19 @@ TEST(ReceivedMessageAgeTest, TestMessagesWithDifferentDefaultTimes) {
       stats = msg_collector.GetStatisticsResults();
       EXPECT_EQ(i + 1, stats.sample_count) << "Expect " << i + 1 << " samples to be collected";
       fake_now_nanos_++;
+    }
+  }
+  {
+    // Initialize message_info source_timestamp at random time and fake_now_nanos_ at 0
+    ReceivedMessageAgeCollector msg_collector{};
+    rmw_message_info_t message_info = rmw_get_zero_initialized_message_info();
+    message_info.source_timestamp = kDefaultTimeMessageReceived;
+    auto fake_now_nanos_ = 0;
+
+    for (int i = 0; i < kDefaultTimesToTest; ++i) {
+      msg_collector.OnMessageReceived(message_info, fake_now_nanos_);
+      stats = msg_collector.GetStatisticsResults();
+      EXPECT_EQ(0, stats.sample_count) << "Expect 0 samples to be collected";
     }
   }
 }

--- a/test/topic_statistics_collector/test_received_message_age.cpp
+++ b/test/topic_statistics_collector/test_received_message_age.cpp
@@ -17,13 +17,7 @@
 #include <chrono>
 #include <string>
 
-#include "libstatistics_collector/msg/dummy_message.hpp"
-#include "libstatistics_collector/msg/dummy_custom_header_message.hpp"
-#include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_age.hpp"
-
-#include "rcl/time.h"
-
 #include "rmw/types.h"
 
 namespace
@@ -115,8 +109,8 @@ TEST(ReceivedMessageAgeTest, TestAgeMeasurement) {
 }
 
 TEST(ReceivedMessageAgeTest, TestGetStatNameAndUnit) {
-  ReceivedMessageAgeCollector test_untyped_collector{};
+  ReceivedMessageAgeCollector test_collector{};
 
-  EXPECT_FALSE(test_untyped_collector.GetMetricName().empty());
-  EXPECT_FALSE(test_untyped_collector.GetMetricUnit().empty());
+  EXPECT_FALSE(test_collector.GetMetricName().empty());
+  EXPECT_FALSE(test_collector.GetMetricUnit().empty());
 }

--- a/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/test/topic_statistics_collector/test_received_message_period.cpp
@@ -29,9 +29,7 @@
 
 namespace
 {
-using ReceivedIntMessagePeriodCollector =
-  libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<int>;
-using ReceivedUntypedMessagePeriodCollector =
+using ReceivedMessagePeriodCollector =
   libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<>;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
@@ -42,8 +40,10 @@ constexpr const double kExpectedMaxMilliseconds{1000.0};
 constexpr const double kExpectedStandardDeviation{0.0};
 }  // namespace
 
-TEST(ReceivedMessagePeriodTest, TestUntypedPeriodMeasurement) {
-  ReceivedUntypedMessagePeriodCollector test{};
+TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
+  ReceivedMessagePeriodCollector test{};
+  libstatistics_collector::moving_average_statistics::StatisticData stats;
+
   rmw_message_info_t msg_info = rmw_get_zero_initialized_message_info();
 
   EXPECT_FALSE(test.IsStarted()) << "Expected to be not started after constructed";
@@ -52,88 +52,25 @@ TEST(ReceivedMessagePeriodTest, TestUntypedPeriodMeasurement) {
   EXPECT_TRUE(test.IsStarted()) << "Expected to be started";
 
   rcl_time_point_value_t fake_now_nanos_{1};
-  msg_info.received_timestamp = fake_now_nanos_;
 
-  test.OnMessageReceived(msg_info);
-  auto stats = test.GetStatisticsResults();
-  EXPECT_EQ(0, stats.sample_count) << "Expected 0 samples to be collected";
+  for (int i = 0; i < 4; i++) {
+    test.OnMessageReceived(msg_info, fake_now_nanos_);
+    stats = test.GetStatisticsResults();
+    EXPECT_EQ(i, stats.sample_count) << "Expected " << i << " samples to be collected";
 
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-  msg_info.received_timestamp = fake_now_nanos_;
+    fake_now_nanos_ +=
+      std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
+  }
 
-  test.OnMessageReceived(msg_info);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(1, stats.sample_count) << "Expected 1 sample to be collected";
-
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-  msg_info.received_timestamp = fake_now_nanos_;
-
-  test.OnMessageReceived(msg_info);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(2, stats.sample_count) << "Expected 2 samples to be collected";
-
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-  msg_info.received_timestamp = fake_now_nanos_;
-
-  test.OnMessageReceived(msg_info);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(3, stats.sample_count);
   EXPECT_EQ(kExpectedAverageMilliseconds, stats.average);
   EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
   EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
   EXPECT_EQ(kExpectedStandardDeviation, stats.standard_deviation);
 }
 
-TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
-  ReceivedIntMessagePeriodCollector test{};
-
-  EXPECT_FALSE(test.IsStarted()) << "Expected to be not started after constructed";
-
-  EXPECT_TRUE(test.Start()) << "Expected Start() to be successful";
-  EXPECT_TRUE(test.IsStarted()) << "Expected to be started";
-
-  rcl_time_point_value_t fake_now_nanos_{1};
-
-  test.OnMessageReceived(kDefaultMessage, fake_now_nanos_);
-  auto stats = test.GetStatisticsResults();
-  EXPECT_EQ(0, stats.sample_count) << "Expected 0 samples to be collected";
-
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-
-  test.OnMessageReceived(kDefaultMessage, fake_now_nanos_);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(1, stats.sample_count) << "Expected 1 sample to be collected";
-
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-
-  test.OnMessageReceived(kDefaultMessage, fake_now_nanos_);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(2, stats.sample_count) << "Expected 2 samples to be collected";
-
-  fake_now_nanos_ +=
-    std::chrono::duration_cast<std::chrono::nanoseconds>(kDefaultDurationSeconds).count();
-
-  test.OnMessageReceived(kDefaultMessage, fake_now_nanos_);
-  stats = test.GetStatisticsResults();
-  EXPECT_EQ(3, stats.sample_count);
-  EXPECT_EQ(kExpectedAverageMilliseconds, stats.average);
-  EXPECT_EQ(kExpectedMinMilliseconds, stats.min);
-  EXPECT_EQ(kExpectedMaxMilliseconds, stats.max);
-  EXPECT_EQ(kExpectedStandardDeviation, stats.standard_deviation);
-}
 
 TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
-  ReceivedIntMessagePeriodCollector test{};
-
-  EXPECT_FALSE(test.GetMetricName().empty());
-  EXPECT_FALSE(test.GetMetricUnit().empty());
-
-  ReceivedUntypedMessagePeriodCollector untyped_test{};
+  ReceivedMessagePeriodCollector untyped_test{};
 
   EXPECT_FALSE(untyped_test.GetMetricName().empty());
   EXPECT_FALSE(untyped_test.GetMetricUnit().empty());

--- a/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/test/topic_statistics_collector/test_received_message_period.cpp
@@ -16,15 +16,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <string>
 #include <thread>
 
 #include "libstatistics_collector/moving_average_statistics/types.hpp"
-#include "libstatistics_collector/topic_statistics_collector/constants.hpp"
 #include "libstatistics_collector/topic_statistics_collector/received_message_period.hpp"
-
-#include "rcl/time.h"
-
 #include "rmw/types.h"
 
 namespace
@@ -33,7 +28,6 @@ using ReceivedMessagePeriodCollector =
   libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<>;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
-constexpr const int kDefaultMessage{42};
 constexpr const double kExpectedAverageMilliseconds{1000.0};
 constexpr const double kExpectedMinMilliseconds{1000.0};
 constexpr const double kExpectedMaxMilliseconds{1000.0};
@@ -68,10 +62,9 @@ TEST(ReceivedMessagePeriodTest, TestPeriodMeasurement) {
   EXPECT_EQ(kExpectedStandardDeviation, stats.standard_deviation);
 }
 
-
 TEST(ReceivedMessagePeriodTest, TestGetStatNameAndUnit) {
-  ReceivedMessagePeriodCollector untyped_test{};
+  ReceivedMessagePeriodCollector test{};
 
-  EXPECT_FALSE(untyped_test.GetMetricName().empty());
-  EXPECT_FALSE(untyped_test.GetMetricUnit().empty());
+  EXPECT_FALSE(test.GetMetricName().empty());
+  EXPECT_FALSE(test.GetMetricUnit().empty());
 }

--- a/test/topic_statistics_collector/test_received_message_period.cpp
+++ b/test/topic_statistics_collector/test_received_message_period.cpp
@@ -24,8 +24,7 @@
 
 namespace
 {
-using ReceivedMessagePeriodCollector =
-  libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<>;
+using ReceivedMessagePeriodCollector = libstatistics_collector::ReceivedMessagePeriodCollector;
 
 constexpr const std::chrono::seconds kDefaultDurationSeconds{1};
 constexpr const double kExpectedAverageMilliseconds{1000.0};


### PR DESCRIPTION
This is a response to issue #168, which aims to transition libstatistics_collector to use `rmw_message_info_t` as the basic type system compared to custom type `T`. There was obviously more code added, but this should be gone after the next major release, as the guidelines say we can remove deprecated code after a full release cycle. All of the generic programming and templates can be removed methods like `HasHeader` won't be useful anymore so this will in the long run make the code compile much faster, since we know the defined type. 

There were a few places where I made some questionable decisions, first I set our `ReceivedMessageAgeCollector` and similar classes to have a default type, just of type `int`. If the user sets the type to `rmw_message_info_t` there's a chance they may trigger the original, now deprecated method. I thought it was a bit over the top to create a duplicate class that wasn't typed, especially since this shouldn't be permanent, but I just wanted to bring up concerns.  

Also, the new `OnMessageReceived` Methods remove the `now_nanoseconds` argument, instead taking advantage of `rmw_message_info_t`'s [`received_timestamp`](https://github.com/ros2/rmw/blob/rolling/rmw/include/rmw/types.h#L654). Going down [the chain](https://github.com/ros2/rcutils/blob/ae82f7ea5f8797b145683a61e6142a02a63b53a4/include/rcutils/time.h#L48) it ends up being the same type as all forms of nanosecond, so there are less conversion issues. Though, my main concern is how inaccurate it is in comparison to the topic statistics, so it's handled in a DDS or RTPS like [here](https://github.com/ros2/rmw_fastrtps/blob/c49991e8bfe3cfff15f87da2f04d3ada2c70d58c/rmw_fastrtps_shared_cpp/src/rmw_response.cpp#L86), occuring exactly when the message is received. Didn't think this was going to create an accuracy, or stability issues, but I'm just making sure.

- Closes #168