### PR TITLE
Switch to using target_link_libraries everywhere.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,12 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-ament_target_dependencies(${PROJECT_NAME}
-  "builtin_interfaces"
-  "rcl"
-  "rmw"
-  "rcpputils"
-  "statistics_msgs"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${builtin_interfaces_TARGETS}
+  rcl::rcl
+  rcpputils::rcpputils
+  rmw::rmw
+  ${statistics_msgs_TARGETS}
 )
 
 install(
@@ -83,22 +83,18 @@ if(BUILD_TESTING)
   ament_add_gtest(test_collector
     test/collector/test_collector.cpp)
   target_link_libraries(test_collector ${PROJECT_NAME})
-  ament_target_dependencies(test_collector "rcpputils")
 
   ament_add_gtest(test_moving_average_statistics
     test/moving_average_statistics/test_moving_average_statistics.cpp)
   target_link_libraries(test_moving_average_statistics ${PROJECT_NAME})
-  ament_target_dependencies(test_moving_average_statistics "rcpputils")
 
   ament_add_gtest(test_received_message_period
     test/topic_statistics_collector/test_received_message_period.cpp)
-  target_link_libraries(test_received_message_period ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_period "rcl" "rmw" "rcpputils")
+  target_link_libraries(test_received_message_period ${PROJECT_NAME} rcl::rcl rmw::rmw)
 
   ament_add_gtest(test_received_message_age
     test/topic_statistics_collector/test_received_message_age.cpp)
-  target_link_libraries(test_received_message_age ${PROJECT_NAME})
-  ament_target_dependencies(test_received_message_age "rcl" "rmw" "rcpputils")
+  target_link_libraries(test_received_message_age ${PROJECT_NAME} rcl::rcl rmw::rmw)
 
   rosidl_generate_interfaces(libstatistics_collector_test_msgs
     "test/msg/DummyMessage.msg"


### PR DESCRIPTION
There is just no need to use ament_target_dependencies here.