### PR TITLE
humble: add missing <cstdint> include 

### DIFF
--- a/src/libstatistics_collector/moving_average_statistics/types.cpp
+++ b/src/libstatistics_collector/moving_average_statistics/types.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 


### PR DESCRIPTION
Add cstdint include to humble.  related to #165 and #172 