### PR TITLE
Lower dependabot update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-    time: "16:16"
-  open-pull-requests-limit: 10
+    interval: monthly
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Reduce churn. There is no real need to look for updates that often or to update to new patch versions.