### PR TITLE
fix: add void annotation

### DIFF
--- a/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
+++ b/include/libstatistics_collector/topic_statistics_collector/received_message_period.hpp
@@ -178,6 +178,8 @@ public:
   {
     std::unique_lock<std::mutex> ulock{mutex_};
 
+    (void) message_info;
+
     if (time_last_message_received_ == kUninitializedTime) {
       time_last_message_received_ = now_nanoseconds;
     } else {


### PR DESCRIPTION
This PR surpresses compiler warning in a package which uses rclcpp_compoent.
```
Starting >>> traffic_light_visualization
--- stderr: traffic_light_visualization                               
In file included from /opt/ros/jazzy/include/rclcpp/rclcpp/topic_statistics/subscription_topic_statistics.hpp:27,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/subscription.hpp:50,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/any_executable.hpp:25,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/memory_strategy.hpp:25,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/memory_strategies.hpp:18,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/executor_options.hpp:20,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/executor.hpp:38,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/executors/multi_threaded_executor.hpp:25,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/executors.hpp:21,
                 from /opt/ros/jazzy/include/rclcpp/rclcpp/rclcpp.hpp:172,
                 from /home/daisuke/workspace/autoware/build/traffic_light_visualization/rclcpp_components/node_main_traffic_light_visualization_node.cpp:21:
/opt/ros/jazzy/include/libstatistics_collector/libstatistics_collector/topic_statistics_collector/received_message_period.hpp: In member function ‘virtual void libstatistics_collector::topic_statistics_collector::ReceivedMessagePeriodCollector<rmw_message_info_s, void>::OnMessageReceived(const rmw_message_info_t&, rcl_time_point_value_t)’:
/opt/ros/jazzy/include/libstatistics_collector/libstatistics_collector/topic_statistics_collector/received_message_period.hpp:175:32: error: unused parameter ‘message_info’ [-Werror=unused-parameter]
  175 |     const rmw_message_info_t & message_info,
```