### PR TITLE
Fix MovingAverageStatistics::max_ Default Value

### DIFF
--- a/include/libstatistics_collector/moving_average_statistics/moving_average.hpp
+++ b/include/libstatistics_collector/moving_average_statistics/moving_average.hpp
@@ -128,7 +128,7 @@ private:
   mutable std::mutex mutex_;
   double average_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
   double min_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = std::numeric_limits<double>::max();
-  double max_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = std::numeric_limits<double>::min();
+  double max_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = std::numeric_limits<double>::lowest();
   double sum_of_square_diff_from_mean_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
   uint64_t count_ RCPPUTILS_TSA_GUARDED_BY(mutex_) = 0;
 };

--- a/src/libstatistics_collector/moving_average_statistics/moving_average.cpp
+++ b/src/libstatistics_collector/moving_average_statistics/moving_average.cpp
@@ -73,7 +73,7 @@ void MovingAverageStatistics::Reset()
   std::lock_guard<std::mutex> guard{mutex_};
   average_ = 0;
   min_ = std::numeric_limits<double>::max();
-  max_ = std::numeric_limits<double>::min();
+  max_ = std::numeric_limits<double>::lowest();
   sum_of_square_diff_from_mean_ = 0;
   count_ = 0;
 }

--- a/test/moving_average_statistics/test_moving_average_statistics.cpp
+++ b/test/moving_average_statistics/test_moving_average_statistics.cpp
@@ -146,6 +146,29 @@ TEST_F(MovingAverageStatisticsTestFixture, TestGetStatisticsInt) {
   EXPECT_EQ(result.sample_count, kExpectedSize);
 }
 
+TEST_F(MovingAverageStatisticsTestFixture, TestGetStatisticsAllNegative) {
+  moving_average_statistics_->Reset();
+
+  constexpr double data_negative[] = {-1.f, -2.f, -3.f, -4.f, -5.f, -6.f, -7.f, -8.f, -9.f, -10.f};
+
+  constexpr double kExpectedAverage = -5.5;
+  constexpr double kExpectedMinimum = -10;
+  constexpr double kExpectedMaximum = -1;
+  constexpr double kExpectedStd = 2.8722813232690143;
+  constexpr int kExpectedSize = 10;
+
+  for (auto d : data_negative) {
+    moving_average_statistics_->AddMeasurement(d);
+  }
+
+  auto result = moving_average_statistics_->GetStatistics();
+  EXPECT_DOUBLE_EQ(result.average, kExpectedAverage);
+  EXPECT_DOUBLE_EQ(result.min, kExpectedMinimum);
+  EXPECT_DOUBLE_EQ(result.max, kExpectedMaximum);
+  EXPECT_DOUBLE_EQ(result.standard_deviation, kExpectedStd);
+  EXPECT_EQ(result.sample_count, kExpectedSize);
+}
+
 TEST_F(MovingAverageStatisticsTestFixture, TestReset) {
   moving_average_statistics_->AddMeasurement(0.6);
   moving_average_statistics_->Reset();


### PR DESCRIPTION
Initializing MovingAverageStatistics::max_ to std::numeric_limits<double>::lowest() instead of std::numeric_limits<double>::min() to ensure correct behavior when dealing with all negative data.

Signed-off-by: Jeffery Hsu <jefferyyjhsu@gmail.com>